### PR TITLE
ENHANCEMENT: Ignore macOS folder attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /.idea/
 /.gradle/
+.DS_STORE


### PR DESCRIPTION
Adds `.DS_STORE` to the .gitignore file.

.DS_STORE is a useless folder attribute file that serves no purpose to non-mac users.